### PR TITLE
FLA-910: Update JDBC driver & mysql-connector to latest

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+application-dev.yml
+
 .gradle
 build/
 !gradle/wrapper/gradle-wrapper.jar

--- a/build.gradle
+++ b/build.gradle
@@ -24,26 +24,20 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
     implementation 'org.springframework.boot:spring-boot-starter-webflux'
     implementation 'org.springframework.boot:spring-boot-starter-data-jdbc'
-    testImplementation 'junit:junit:4.13.1'
-    implementation 'mysql:mysql-connector-java:8.0.28'
-
+    implementation 'com.mysql:mysql-connector-j:9.4.0'
+    implementation 'no.fintlabs:flais-operator-starter:1.0.0-rc-9'
+    implementation 'org.postgresql:postgresql:42.7.2'
+    implementation 'io.netty:netty-resolver-dns-native-macos:4.1.85.Final:osx-aarch_64'
 
     runtimeOnly 'io.micrometer:micrometer-registry-prometheus'
-
-    implementation 'io.netty:netty-resolver-dns-native-macos:4.1.85.Final:osx-aarch_64'
-    testImplementation 'org.spockframework:spock-core'
-
 
     compileOnly 'org.projectlombok:lombok'
 
     annotationProcessor 'org.projectlombok:lombok'
-
-    implementation 'no.fintlabs:flais-operator-starter:1.0.0-rc-9'
-
-    runtimeOnly 'org.postgresql:postgresql'
-
     annotationProcessor 'io.fabric8:crd-generator-apt:6.2.0'
 
+    testImplementation 'org.spockframework:spock-core'
+    testImplementation 'junit:junit:4.13.1'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'cglib:cglib-nodep:3.3.0'
     testImplementation 'org.spockframework:spock-spring:2.3-groovy-4.0'

--- a/kustomize/base/kustomization.yaml
+++ b/kustomize/base/kustomization.yaml
@@ -20,3 +20,4 @@ commonLabels:
   app.kubernetes.io/part-of: fintlabs-application-infrastructure-services
   fintlabs.no/team: flais
   fintlabs.no/org-id: flais.io
+  observability.fintlabs.no/loki: "true"


### PR DESCRIPTION
This PR includes the following:
- Update and specify JDBC driver to v42.7.2
- Supports PG 10-17
- Update mysql-connector to v9.4.0 because its used in tests
- Enable logging